### PR TITLE
Make getMachOExecutable more general

### DIFF
--- a/ipa_installer/ipa_installer.py
+++ b/ipa_installer/ipa_installer.py
@@ -81,7 +81,7 @@ def getMachOExecutable(app_path):
         path = os.path.join(app_path, filename)
         if not os.path.isdir(path):
             output = subprocess.check_output(['file', path])
-            if "Mach-O universal binary" in output:
+            if "Mach-O" in output:
                 output = output.split(":")[0]
                 break
     return os.path.join(app_path, output)


### PR DESCRIPTION
I've got the following error by running the current version of the library: 
```
Traceback (most recent call last):
  File "ipa_installer.py", line 167, in <module>
    subprocess.check_output([optool_path, "install", "-c", "load", "-p", "@executable_path/FridaGadget.dylib", "-t", executable_filepath])
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['optool/bin/optool', 'install', '-c', 'load', '-p', '@executable_path/FridaGadget.dylib', '-t', '/tmp/appmon_ipa/myApp/Payload/myApp.app/PkgInfo: ASCII text, with no line terminators\n']' returned non-zero exit status 1
```
The cause of the error was that the function `getMachOExecutable` returned `PkgInfo: ASCII text, with no line terminators`. 

The reason for that was the fact that `file /tmp/appmon_ipa/myApp/Payload/myApp.app/myApp` returned `myApp: Mach-O executable arm_v7`, so `getMachOExecutable` did not find it.

This PR addresses this issue.