### PR TITLE
appintruder.py patch for Windows

### DIFF
--- a/intruder/appintruder.py
+++ b/intruder/appintruder.py
@@ -266,4 +266,9 @@ def signal_handler(signal, frame):
     _exit_()
 
 signal.signal(signal.SIGINT, signal_handler)
-signal.pause()
+try:
+    signal.pause()
+except AttributeError:
+    # signal.pause() is missing for Windows; wait 1ms and loop instead
+    while True:
+        time.sleep(0.001)


### PR DESCRIPTION
signal.pause() is missing for Windows; wait 1ms and loop instead.
Idea from https://github.com/OpenRCE/sulley/pull/78.