### PR TITLE
add support for attaching to pids by-number (v3)

### DIFF
--- a/appmon.py
+++ b/appmon.py
@@ -284,7 +284,6 @@ rpc.exports = {
         print colored("[ERROR] " + str(e), "red")
         traceback.print_exc()
 
-
 def init_session():
     try:
         session = None
@@ -340,7 +339,11 @@ def init_session():
                         traceback.print_exc()
                         sys.exit(1)
                 else:
-                    session = device.attach(app_name)
+                    arg_to_attach = app_name
+                    if app_name.isdigit():
+                        arg_to_attach = int(app_name)
+
+                    session = device.attach(arg_to_attach)
             except Exception as e:
                 print colored('[ERROR] ' + str(e), 'red')
                 traceback.print_exc()


### PR DESCRIPTION
v2:
	* define isInterger as a function sibling to init_session instead of a in-line declaration of the function in an else block (dpnishant , https://github.com/dpnishant/appmon/pull/44#issuecomment-323856974)