### PR TITLE
Fix "Invalid format string" in Windows

### DIFF
--- a/appmon.py
+++ b/appmon.py
@@ -157,7 +157,7 @@ def on_detached():
     print colored('[WARNING] "%s" has terminated!' % (app_name), 'red')
 
 def on_message(message, data):
-    current_time = time.strftime('%b %d %Y %l:%M %p', time.localtime())
+    current_time = time.strftime('%b %d %Y %I:%M %p', time.localtime())
     global output_dir
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -23,7 +23,7 @@ def save_to_database(db_path, str_json):
     str_json = json.loads(str_json.replace("\n", "<br />").replace("\r", "<br />"), strict=False)
     db = dataset.connect('sqlite:///%s' % (db_path.replace("'", "_")))
     table = db['api_captures']
-    table.insert(dict(time=time.strftime('%b %d %Y %l:%M %p', time.localtime()),
+    table.insert(dict(time=time.strftime('%b %d %Y %I:%M %p', time.localtime()),
       operation=str_json['txnType'],
       artifact=json.dumps(str_json['artifact']),
       method=str_json['method'],


### PR DESCRIPTION
ValueError: Invalid format string

%l is not standard: %l - Hour of the day, 12-hour clock, blank-padded ( 1..12)

The Windows implementations doesn't support it:
https://msdn.microsoft.com/en-us/library/fe06s4ak.aspx
https://docs.python.org/3/library/time.html

Use %I instead: %I - Hour of the day, 12-hour clock, zero-padded (01..12)