### PR TITLE
adding windows compatibility

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -16,6 +16,7 @@
 ###
 
 import dataset, json, time, htmlentities
+import platform as platform_module
 from xml.sax.saxutils import escape
 
 def save_to_database(db_path, str_json):
@@ -23,7 +24,12 @@ def save_to_database(db_path, str_json):
     str_json = json.loads(str_json.replace("\n", "<br />").replace("\r", "<br />"), strict=False)
     db = dataset.connect('sqlite:///%s' % (db_path.replace("'", "_")))
     table = db['api_captures']
-    table.insert(dict(time=time.strftime('%b %d %Y %l:%M %p', time.localtime()),
+    os_string = platform_module.system()
+    if os_string == "Windows":
+        formatted_time = time.strftime('%b %d %Y %I:%M %p', time.localtime())
+    else:
+        formatted_time = time.strftime('%b %d %Y %l:%M %p', time.localtime())
+    table.insert(dict(time=formatted_time,
       operation=str_json['txnType'],
       artifact=json.dumps(str_json['artifact']),
       method=str_json['method'],

--- a/viewreport.py
+++ b/viewreport.py
@@ -65,8 +65,10 @@ def landing_page():
     global APP_LIST
     global DB_MAP
     APP_LIST = []
-    for root, dirs, files in os.walk('./app_dumps'):
-        path = root.split('/')
+    
+    app_dumps_dir = os.path.join('.','app_dumps')
+    for root, dirs, files in os.walk(app_dumps_dir):
+        path = root.split(os.sep)
         for file in files:
             file_path = os.path.join(root, file)
             if file_path.endswith('.db'):


### PR DESCRIPTION
Based on the work from #55 I created a pull request that addresses several Windows compatibility issues in the code and dpnishant's concern about regression failures in *nix platforms. It does the following things:
1) Uses the  Python platform module to determine the OS and call time.strftime appropriately. On non-windows systems it uses the old call.
2) Changes all hardcoded "/"s in paths to use either os.sep, or os.path.join
3) Uses the Python tempfile module to replace the hardcoded reference to "/tmp"

I tested this on Windows 10 and MacOS 10.11.6 successfully, using the following launch parameters: -a iGoat -p ios -s scripts/iOS --spawn 1