### PR TITLE
Link fix for Documentation (GitHub Pages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ New/Experimental Features
 Documentation
 =============
 Follow the documentation below to learn more.
-[Click Here](https://dpnishant.github.com/appmon/)
+[Click Here](https://dpnishant.github.io/appmon/)
 
 
 Credits


### PR DESCRIPTION
Subdomains of github.com are deprecated for GitHub Pages. They will not redirect to github.io after April 15, 2021.