### PR TITLE
Changed frida releases url in apk_builder/getlibs.sh

### DIFF
--- a/apk_builder/getlibs.sh
+++ b/apk_builder/getlibs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir lib
 cd lib
-wget -qO - https://github.com/frida/frida/releases/latest | grep -o "\/frida\/frida\/releases\/download\/.*\/frida-gadget-.*-android-.*\.so\.xz" | sed 's/\/frida\/frida/https:\/\/github\.com\/frida\/frida/g' | sed 's/%0A/\n/g' > list.txt
+wget -qO - https://api.github.com/repos/frida/frida/releases/latest | grep -o "\/frida\/frida\/releases\/download\/.*\/frida-gadget-.*-android-.*\.so\.xz" | sed 's/\/frida\/frida/https:\/\/github\.com\/frida\/frida/g' | sed 's/%0A/\n/g' > list.txt
 wget -i list.txt
 unxz *.xz
 mkdir arm64 arm64-v8a armeabi armeabi-v7a x86 x86_64


### PR DESCRIPTION
This change is necessary since wget makes requests without waiting for javascript to execute. On github releases pages, if the list of assets is long, a request is made for retrieving the assets that will not be in the list wget would have.

The new link is a REST API link that consistently gets the assets of the latest release.